### PR TITLE
Runtime foreman options + post-deploy-hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ script:
   - cd 9.1/
   - docker build -t maestrano/web-jruby:travis . > /dev/null 2>&1
 
+  #=======================================
+  # Test with minimal parameters
+  #=======================================
   # Run image
   - docker run -P -d --name travis-test -e GIT_URL=https://github.com/alachaum/sample_app_rails_4 -e GIT_BRANCH=master maestrano/web-jruby:travis
 
@@ -26,3 +29,26 @@ script:
 
   # Check that application is up
   - "curl http://${container_ip}:80/"
+
+  # Remove container
+  - docker rm -f travis-test
+
+  #=======================================
+  # Test with foreman options
+  #=======================================
+  # Run image
+  - docker run -P -d --name travis-test -e FOREMAN_OPTS="-m web=1" -e GIT_URL=https://github.com/alachaum/sample_app_rails_4 -e GIT_BRANCH=master maestrano/web-jruby:travis
+
+  # Get ip address
+  - "container_ip=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' travis-test`"
+
+  # Wait for container to be ready
+  - try_count=0;
+  - HEALTH_CHECK="starting"
+  - while [ "$HEALTH_CHECK" == "starting" ] || [ "$HEALTH_CHECK" == "unhealthy" ]; do let "try_count++"; [ $try_count -gt 100 ] && exit 20; sleep 5; HEALTH_CHECK=$(docker inspect --format='{{.State.Health.Status}}' travis-test 2>/dev/null); done
+
+  # Check that application is up
+  - "curl http://${container_ip}:80/"
+
+  # Remove container
+  - docker rm -f travis-test

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -48,5 +48,10 @@ fi
 # Update ownership
 chown -R www-data:www-data /app /var/log/app
 
+# Run post-deploy hook
+if [ -f /app/.post-deploy-hook ]; then
+  [ "$NO_HOOK" == "true" ] || bash /app/.post-deploy-hook
+fi
+
 # Perform command - default is "foreman start" (see Dockerfile)
 exec "$@"

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -5,6 +5,7 @@ set -e
 cd /app
 
 # Set default environment variables
+export FOREMAN_OPTS=${FOREMAN_OPTS:-""}
 export RACK_ENV=${RACK_ENV:-production}
 export RAILS_ENV=${RAILS_ENV:-production}
 export RAILS_LOG_TO_STDOUT=${RAILS_LOG_TO_STDOUT:-true}

--- a/9.1/supervisord.conf
+++ b/9.1/supervisord.conf
@@ -4,7 +4,7 @@ pidfile=/var/run/supervisord.pid
 nodaemon=true
 
 [program:app]
-command=/usr/local/bundle/bin/foreman start -d /app -p 3000
+command=/usr/local/bundle/bin/foreman start -d /app -p 3000 %(ENV_FOREMAN_OPTS)s
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ web: bundle exec puma -t 5:5 -p ${PORT:-3000}
 worker: bundle exec rake jobs:work
 ```
 
+The foreman configuration can be overriden at runtime by setting the `FOREMAN_OPTS` environment variable. Considering the Procfile above running the following command would only run the "web" proc.
+
+```
+docker run -P -d -e FOREMAN_OPTS="-m web=1" -e GIT_URL=https://github.com/alachaum/sample_app_rails_4 maestrano/web-jruby
+```
+
 ## Logging
 For Rails 4 you may want to add the `rails_12factor` gem to your Gemfile under the `production` group to redirect output to STDOUT. For Rails 5 you can add STDOUT logging directly your production.rb file.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Just drop a `nginx.conf` file in the root of your folder and it will automatical
 
 The default nginx configuration file is [available here](9.1/app.conf).
 
-## Deploy hook
+## Deploy hooks
+
+### .deploy-hook
 If you need to perform specific configuration activities at deploy time - such as fetching a file from a remote S3 repository - you can specify a deploy hook at the root of your project called ".deploy-hook". This file must be a shell script. Any environment variable passed to the container will be available to the deploy-hook script. The deploy-hook script is run after the project has been checked out and before bundler is run.
 
 **Example:** PROJECT_ROOT/.deploy-hook
@@ -59,6 +61,9 @@ echo "This is a deploy hook!"
 echo "I run after checkout..."
 echo "...and before bundler"
 ```
+
+### .post-deploy-hook
+The post-deploy-hook behavior is similar to the deploy-hook, but it is run after the deployment and just before last command is performed (e.g. "foreman start").
 
 ## Docker Healthcheck
 The image provides a **default Docker healthcheck** which curls your app on the root path. You can customize this healthcheck by adding a `.healthcheck` in the root directory of your application. This healtcheck file should be a bash script returning a non-zero exit code on failure. The healthcheck can be completely disabled by adding "NO_HEALTHCHECK=true" to the list of container environment variables.


### PR DESCRIPTION
- Add ability to configure foreman runtime options
- Backport post-deploy-hook from https://github.com/maestrano/docker-web-ruby/pull/16