### PR TITLE
Upgrade to jruby-9.1.10 and set default JRUBY_OPTS env var

### DIFF
--- a/9.1/Dockerfile
+++ b/9.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM jruby:9.1.8
+FROM jruby:9.1.10
 
 # Install System libraries
 RUN apt-get update && apt-get install -y \

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -11,6 +11,7 @@ export RAILS_ENV=${RAILS_ENV:-production}
 export RAILS_LOG_TO_STDOUT=${RAILS_LOG_TO_STDOUT:-true}
 export GIT_BRANCH=${GIT_BRANCH:-master}
 export BUNDLE_JOBS=${BUNDLE_JOBS:-$(nproc)} # default to number of cores
+export JRUBY_OPTS=${JRUBY_OPTS:-"-J-server -J-XX:+CMSClassUnloadingEnabled -J-XX:+UseConcMarkSweepGC -J-Djava.security.egd=file:/dev/urandom"}
 
 # Configure bundler to use gemstash server if specified
 if [ -n "$GEMSTASH_SERVER" ]; then


### PR DESCRIPTION
- Upgrade to Jruby-9.1.10
- Set default JRUBY_OPTS:
  - `-J-Djava.security.egd` (see: https://github.com/jruby/jruby/issues/4644)
  - GC tuning with `CMSClassUnloadingEnabled` and `UseConcMarkSweepGC` (see https://github.com/jruby/jruby/wiki/Troubleshooting-Memory-Use)
  - `-J-server` (see https://github.com/jruby/jruby/wiki/PerformanceTuning)