### PR TITLE
Upgrade to jruby-9.1.12.0

### DIFF
--- a/9.1/Dockerfile
+++ b/9.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM jruby:9.1.10
+FROM jruby:9.1.12
 
 # Install System libraries
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
To keep on hold, jruby-9.1.12.0 throws errors when running rubocop on other projects. I need to analyse the impact before upgrading.